### PR TITLE
fix: change get rides api path

### DIFF
--- a/routes/rides.js
+++ b/routes/rides.js
@@ -14,7 +14,7 @@ const {
 } = require('../controllers/rides')
 
 router.route('/').get(getRides)
-router.route('/:id').get(getRide)
+router.route('/get/:id').get(getRide)
 
 router.route('/create/:id').post(createRide)
 router.route('/edit/:id').put(editRide)


### PR DESCRIPTION
The previous API path for getting a single ride was `/api/rides/:id`,
which conflicted with the API path for getting multiple rides:
`/api/rides/`. This is because `/:id` can take in a value of `null`,
meaning nothing was passed after the `/`.

This would result in accidental calls to both API paths, passing `null`
to the function for getting a single ride. This would result in errors
like

```
CastError: Cast to ObjectId failed for value "null"
```

To resolve this, I've changed the api path for getting a single ride
from `/api/rides/:id` to `/api/rides/get/:id`, which likewise needs to
be updated on the frontend.

Sidenote: getting users is not encountering this issue because there
does not exist a route for getting all users.

Signed-off-by: Lucas Sta Maria <lucas.stamaria@gmail.com>